### PR TITLE
feat: Add server-side persistence for card sorting

### DIFF
--- a/components/board/board.tsx
+++ b/components/board/board.tsx
@@ -51,7 +51,6 @@ const Board = () => {
   const { visibleLists, hiddenLists } = useMemo(() => {
     const visible = enrichedLists.filter(list => !list.collapsed);
     const hidden = enrichedLists.filter(list => list.collapsed);
-
     return {
       visibleLists: visible,
       hiddenLists: hidden,
@@ -90,7 +89,7 @@ const Board = () => {
                       }
                     >
                       <Droppable key={list.id} id={list.id}>
-                        <ListColumn list={list} />
+                        <ListColumn list={list} key={list.id} />
                       </Droppable>
                     </div>
                   ))

--- a/components/board/list-column.tsx
+++ b/components/board/list-column.tsx
@@ -2,13 +2,14 @@ import { useUpdateCardPriority } from "@/hooks/use-cards";
 import { useToggleListCollapsed } from "@/hooks/use-lists";
 import type { Card } from "@/types/database";
 import { List } from "@/types/database";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { Ellipsis, Plus } from "lucide-react";
 
 import { useState, memo, useCallback, JSX } from "react";
 
 import AddCardTrigger from "@/components/board/add-card-trigger";
 import CardItem from "@/components/board/card-item";
-import { Draggable } from "@/components/dnd/draggable";
+import { SortableCardItem } from "@/components/dnd/sortable-card-item";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 type ListColumnProps = {
@@ -99,11 +100,16 @@ const ListColumnComponent: ({ list, isOver }: ListColumnProps) => JSX.Element = 
 
       {/* List Content */}
       <div className="flex-1 space-y-2 p-2 min-h-0 relative isolation-isolate overflow-y-auto overflow-x-hidden">
-        {list.cards?.map((card: Card) => (
-          <Draggable key={card.id} id={card.id} data={{ listId: list.id }}>
-            <CardItem card={card} color={list.color} onPriorityChange={handlePriorityChange} />
-          </Draggable>
-        ))}
+        <SortableContext
+          items={list.cards?.map(card => card.id) || []}
+          strategy={verticalListSortingStrategy}
+        >
+          {list.cards?.map((card: Card) => (
+            <SortableCardItem key={card.id} id={card.id} listId={list.id}>
+              <CardItem card={card} color={list.color} onPriorityChange={handlePriorityChange} />
+            </SortableCardItem>
+          ))}
+        </SortableContext>
         <AddCardTrigger listId={list.id}>
           <div
             className={`w-full border p-1 flex items-center justify-center rounded-sm transition-all duration-200 bg-muted/20 hover:bg-muted ${listHovered && !isOver ? "opacity-100" : "opacity-0"}`}

--- a/components/dnd/draggable.tsx
+++ b/components/dnd/draggable.tsx
@@ -27,7 +27,7 @@ export function Draggable(props: DraggableProps) {
       style={style}
       {...listeners}
       {...attributes}
-      className={isDragging ? "opacity-0 cursor-grabbing" : "cursor-grab"} // Hide original when dragging
+      className={isDragging ? "opacity-0 cursor-grabbing" : "cursor-grab"}
     >
       {props.children}
     </div>

--- a/components/dnd/droppable.tsx
+++ b/components/dnd/droppable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useDndContext, useDroppable } from "@dnd-kit/core";
+import { useDroppable } from "@dnd-kit/core";
 
 import { cloneElement, ReactElement } from "react";
 
@@ -11,15 +11,15 @@ type DroppableProps = {
 };
 
 export function Droppable(props: DroppableProps) {
-  const { isOver, setNodeRef } = useDroppable({
+  const { setNodeRef, over, active } = useDroppable({
     id: props.id,
     data: props.data,
   });
 
-  const { active } = useDndContext();
   const draggedFromThisList = active?.data?.current?.listId === props.id;
-  const shouldShowOverlay = isOver && !draggedFromThisList;
+  const draggingToThisList = over?.data?.current?.listId === props.id || over?.id === props.id;
 
+  const shouldShowOverlay = !draggedFromThisList && draggingToThisList;
   return (
     <div ref={setNodeRef}>
       {cloneElement(props.children, { isOver: shouldShowOverlay } as { isOver: boolean })}

--- a/components/dnd/sortable-card-item.tsx
+++ b/components/dnd/sortable-card-item.tsx
@@ -1,0 +1,37 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+
+interface SortableCardItemProps {
+  id: string;
+  listId: string;
+  children: React.ReactNode;
+}
+
+export function SortableCardItem({ id, listId, children }: SortableCardItemProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: id,
+    data: {
+      listId: listId,
+    },
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    transformOrigin: "0 0",
+    touchAction: "manipulation",
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="transition-transform duration-200 ease-in-out"
+      {...attributes}
+      {...listeners}
+    >
+      {children}
+    </div>
+  );
+}

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -25,6 +25,11 @@ export const updateCardPrioritySchema = z.object({
   priority: cardPrioritySchema,
 });
 
+export const sortCardInListSchema = z.object({
+  listId: z.string().uuid("Invalid list ID"),
+  orderedCardIds: z.string().array(),
+});
+
 export const moveCardToColumnSchema = z.object({
   cardId: z.string().uuid("Invalid card ID"),
   listId: z.string().uuid("Invalid list ID"),

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "prepare": "husky",
-    "quality": "pnpm run lint && pnpm run format:check && pnpm run type-check",
+    "quality": "pnpm run lint && pnpm run format:check && pnpm run type-check && pnpm run test:run",
     "seed": "tsx prisma/seed.ts",
     "seed:test": "tsx prisma/test-cards-seed.ts"
   },
@@ -39,6 +39,8 @@
   "dependencies": {
     "@auth/prisma-adapter": "^2.9.1",
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@prisma/client": "6.10.1",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.1.0)
       '@prisma/client':
         specifier: 6.10.1
         version: 6.10.1(prisma@6.10.1(typescript@5.8.3))(typescript@5.8.3)
@@ -338,6 +344,12 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
 
   '@dnd-kit/utilities@3.2.2':
     resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
@@ -4196,6 +4208,13 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.0)
+      react: 19.1.0
       tslib: 2.8.1
 
   '@dnd-kit/utilities@3.2.2(react@19.1.0)':

--- a/prisma/test-cards-seed.ts
+++ b/prisma/test-cards-seed.ts
@@ -20,7 +20,7 @@ async function seedTestCards() {
   let board = await prisma.board.findFirst({
     where: {
       userId: user.id,
-      title: "najnoviiji board",
+      title: "mojboard",
     },
     include: { lists: true },
   });


### PR DESCRIPTION
  - Implement Sortable UI functionalities from @dnd-kit
  - Implement reorderCardsInList server action with Prisma transactions
  - Add useReorderCardsInList TanStack mutation hook
  - Fix state synchronization between local state and query cache
  - Add proper error handling and rollback mechanisms